### PR TITLE
Cache conan packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,51 +24,42 @@ jobs:
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.1
 
-  build-linux:
+  build:
     needs: [ pre-commit ]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mercotui/ubahn_buildenv:1.6
+      image: ghcr.io/mercotui/ubahn_buildenv:2025.11.9
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Conan setup
-        run: conan profile detect
-      - name: Conan install
+      - name: Setup conan
+        uses: conan-io/setup-conan@v1
+        with:
+          cache_packages: true
+      - name: Linux - Conan install
         run: conan install -u -pr:a=profiles/linux-wayland.profile --settings=build_type=Debug --build=missing .
-      - name: Cmake configure
+      - name: Linux -  Cmake configure
         run: cmake --preset conan-linux-debug -DUBAHN_VERSION=${{ env.VERSION }}
-      - name: Build
+      - name: Linux - Build
         run: cmake --build --preset conan-linux-debug
-      - name: Test
+      - name: Linux - Test
         run: ctest --preset conan-linux-debug  --output-on-failure
-
-  build-web:
-    needs: [ pre-commit ]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/mercotui/ubahn_buildenv:1.6
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Conan setup
-        run: conan profile detect
-      - name: Conan install
+      - name: Web - Conan install
         run: conan install -u -pr:b=profiles/linux-wayland.profile -pr:h=profiles/emscripten.profile --build=missing --settings=build_type=Release .
-      - name: Cmake configure
+      - name: Web - Cmake configure
         run: cmake --preset conan-emscripten-release -DUBAHN_VERSION=${{ env.VERSION }}
-      - name: Build
+      - name: Web - Build
         run: cmake --build --preset conan-emscripten-release
-      - name: Package
+      - name: Web - Package
         run: cmake --build --preset conan-emscripten-release --target package
-      - name: Store Artifact
+      - name: Web - Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: 'u-bahn'
           path: ${{ format('dist/u-bahn-web-{0}.tar.gz', env.VERSION) }}
 
   release:
-    needs: [ build-web ]
+    needs: [ build ]
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     permissions:

--- a/containers/README.md
+++ b/containers/README.md
@@ -4,14 +4,17 @@ To build and publish the CI container for this project run the following command
 
 ```bash
 podman login ghcr.io
-podman build -f build.containerfile -t ghcr.io/mercotui/ubahn_buildenv:1.x
-podman push ghcr.io/mercotui/ubahn_buildenv:1.x
+podman build -f build.containerfile -t ghcr.io/mercotui/ubahn_buildenv:xx
+podman push ghcr.io/mercotui/ubahn_buildenv:xx
 ```
+
+Note that in `ubahn_buildenv:xx` the `xx` part should be the CALVER version following YYYY.MM.PP scheme.
 
 To test the CI container locally you can use:
 
 ```bash
-podman run -it -v ..:/u-bahn:z <image ID>
+podman run -it -v ..:/u-bahn:z ghcr.io/mercotui/ubahn_buildenv:xx
+pipx install conan
 cd u-bahn
 conan install -u -pr:b=default -pr:h=profiles/emscripten.profile --build=missing --settings=build_type=Release .
 cmake --preset conan-emscripten-release

--- a/containers/build.containerfile
+++ b/containers/build.containerfile
@@ -13,12 +13,12 @@ from quay.io/fedora/fedora-minimal:43
 
 # Install build tools followed by app dependencies
 run dnf update -y && \
-    dnf install -y clang ninja-build cmake pipx git \
+    dnf install -y clang ninja-build cmake pip pipx tar git \
         systemd-devel mesa-libGLES-devel mesa-libEGL-devel SDL3-devel && \
     dnf clean all
 
 # Append pipx install dir to path
 env PATH="$PATH:/root/.local/bin"
 
-# Install conan and poetry
-run pipx install conan poetry
+# Install poetry
+run pipx install poetry


### PR DESCRIPTION
This combines the web build and linux build into one job, as the conan setup action does not support parallel builds:
https://github.com/conan-io/setup-conan/issues/6

If build times balloon in the future I will need to revert back to writing my own conan caching solution.